### PR TITLE
Add stubs for dashboard and for adding/updating simulation

### DIFF
--- a/server/route/dashboard.js
+++ b/server/route/dashboard.js
@@ -1,0 +1,67 @@
+const router = require('express').Router();
+const { isAuthenticated } = require('../auth');
+
+router.get('/', isAuthenticated, (req, res) => {
+  const { instructor_id } = req.body;
+  /*
+    TODO: return dashboard main page
+
+    - path parameter
+    * instructor_id: UID of instructor of a dashboard
+  */
+  res.status(202);
+  res.json({
+    success: true,
+    drafts: [], // simulations
+    open: [], // simulations
+    closed: [], // simulations
+  });
+});
+
+router.delete('/simulation/:simulation_id', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  /*
+    TODO: remove saved simulation
+
+    - path parameter
+    * simulation_id: UID of simulation to be removed.
+  */
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.post('/simulation/:simulation_id/start', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { available_to } = req.body;
+  /*
+    TODO: start and open a simulation
+
+    - path parameter
+    * simulation_id: UID of simulation to be opened.
+
+    - request body
+    * available_to: UID of students who can access the simulation.
+  */
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.post('/simulation/:simulation_id/close', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  /*
+    TODO: close a simulation
+
+    - path parameter
+    * simulation_id: UID of simulation to be closed.
+  */
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+module.exports = router;

--- a/server/route/index.js
+++ b/server/route/index.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const auth = require('./auth');
+const dashboard = require('./dashboard');
+const simulation = require('./simulation');
 const router = express.Router();
 
 router.use('/auth', auth);
+router.use('/dashboard', dashboard);
+router.use('/simulation', simulation);
 
 module.exports = router;

--- a/server/route/simulation.js
+++ b/server/route/simulation.js
@@ -1,0 +1,249 @@
+const router = require('express').Router();
+const { isAuthenticated } = require('../auth');
+
+router.post('/create', isAuthenticated, (req, res) => {
+  const { simulation_name } = req.body;
+
+  /*
+    TODO: create a new simulation
+
+    - request body
+    * simulation_name: name for a new simulation
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+    simulation_id: 1234567,
+  });
+});
+
+router.put('/:simulation_id/introduction', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { description } = req.body;
+
+  /*
+    TODO: Add or update `introduction` part of simulation
+
+    - path variable:
+    * simulation_id: UID of simuluation whose `introduction` is updated.
+
+    - request body:
+    * description: content of `introduction`
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.put('/:simulation_id/project-task-assignment', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { description } = req.body;
+
+  /*
+    TODO: Add or update `project-task-assignment` part of simulation
+
+    - path variable:
+    * simulation_id: UID of simuluation whose `project-task-assignment` is updated.
+
+    - request body:
+    * description: content of `project-task-assignment`
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.put('/:simulation_id/initial-reflection', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { description, questions } = req.body;
+
+  /*
+    TODO: Add or update `initial-reflection` part of simulation
+
+    - path variable:
+    * simulation_id: UID of simuluation whose `initial-reflection` is updated.
+
+    - request body:
+    * description: content of `initial-reflection`
+    * questions: list of questions
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.put('/:simulation_id/initial-action', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { description, choices } = req.body;
+
+  /*
+    TODO: Add or update `initial-action` part of simulation
+
+    - path variable:
+    * simulation_id: UID of simuluation whose `initial-action` is updated.
+
+    - request body:
+    * description: content of `initial-action`
+    * choices: list of choices
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.put('/:simulation_id/stakeholders/description', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { description } = req.body;
+
+  /*
+    TODO: Add or update a summary for all of the stakeholders
+
+    - path variable:
+    * simulation_id: UID of simuluation whose a summary for all of the stakeholders is updated.
+
+    - request body:
+    * description: content of a summary for all of the stakeholders
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.put('/:simulation_id/stakeholders', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { name, description, conversation_text } = req.body;
+
+  /*
+    TODO: Add or update `stakeholder-list` part of simulation
+
+    - path variable:
+    * simulation_id: UID of simuluation where a stakeholder is added or updated
+
+    - request body:
+    * name: name of a stakeholder
+    * description: short description of a new stakeholder
+    * conversation_text: content of conversation with a new stakeholder
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.put('/:simulation_id/additional-reflection', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { description, questions } = req.body;
+
+  /*
+    TODO: Add or update `additional-reflection` part of simulation
+
+    - path variable:
+    * simulation_id: UID of simuluation whose `additional-reflection` is updated.
+
+    - request body:
+    * description: content of `additional-reflection`
+    * questions: list of questions
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+router.put('/:simulation_id/final-action', isAuthenticated, (req, res) => {
+  const { simulation_id } = req.params;
+  const { description, choices } = req.body;
+
+  /*
+    TODO: Add or update `final-action` part of simulation
+
+    - path variable:
+    * simulation_id: UID of simuluation whose `final-action` is updated.
+
+    - request body:
+    * description: content of `final-action`
+    * choices: list of choices
+  */
+
+  res.status(202);
+  res.json({
+    success: true,
+  });
+});
+
+module.exports = router;
+
+/*
+Add “project task assignment”
+i)      POST /api/v1/simulation/project-task-assignment/update
+ii)     Request
+(1)   Simulation ID
+(2)   HTML text for description String description
+iii)   Response
+(1)   Whether the description is added successfully
+c)     Add “reflection on initial information”
+i)      POST /api/v1/simulation/[simulation_id]/initial-reflection
+ii)     Request
+(1)   Simulation ID
+(2)   description (HTML text for description)
+(3)   A list of HTML tag IDs of text boxes for answers
+iii)   Response
+(1)   Whether the description and text boxes are added successfully
+d)    Add “choose initial action”	
+i)      PUT /api/v1/simulation/initial-action
+ii)     Request
+(1)   Simulation ID
+(2)   HTML text for the description
+(3)   A list of strings → tag IDs of choices
+iii)   Response
+See “Canonical Void Response”
+e)    Add descriptions for the page of stakeholders
+i)      PUT /api/v1/simulation/stakeholder-list
+ii)     Request
+(1)   Simulation ID
+(2)   HTML text for description
+iii)   Response
+See “Canonical Void Response”
+f)      Add a stakeholder
+i)      PUT /api/v1/simulation/stakeholder
+ii)     Request
+(1)   Simulation ID
+(2)   The name of a stakeholder
+(3)   HTML text for a brief bio of the stakeholder
+(4)   HTML text for a talk with the stakeholder
+iii)   Response
+
+{
+  "stakeholder_id": Integer,
+}
+
+g)     Add “reflection on additional information”
+i)      PUT /api/v1/simulation/additional-reflection
+ii)     Request
+(1)   Simulation ID
+(2)   HTML text for description
+(3)   A list of HTML tag IDs of text boxes for answers
+iii)   Response
+See “Canonical Void Response”
+h)    Add “final decision"
+i)      PUT /api/v1/simulation/final-decision
+ii)     Request
+(1)   Simulation ID
+(2)   HTML text for the description
+(3)   A list of HTML tag IDs of choices
+iii)   Response
+See “Canonical Void Response”
+ */


### PR DESCRIPTION
### Add stubs for dashboard and for adding/updating simulation

1. Add stubs for dashboard in `server/route/dashboard.js` as a router which deals with requests starting with `/dashboard`.

2. Add stubs for adding/updating simulation in `server/route/simulation.js` as a router which deals with requests starting with `/simulation`.

Since the documentation for endpoints in **google docs** and in **Postman** (which @TsarFox created) **does not match**, I just picked what seems to make sense in the context of functionality of each endpoint. So my code does not fully match the documentation in google docs, nor in Postman. Therefore, before merging my request, I think **we need to figure out this problem of the documentation and edit and write more concrete documentation**. We can talk about it here in this pull-request.