### PR TITLE
Implement initial JWT authentication.

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4639,6 +4639,11 @@
         "isarray": "^1.0.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -6352,6 +6357,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -12125,6 +12138,30 @@
         }
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -12143,6 +12180,25 @@
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.1"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keyv": {
@@ -12310,10 +12366,45 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "bcryptjs": "^2.4.3",
     "express-promise-router": "^4.0.1",
     "express-session": "^1.17.1",
+    "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.6.2",
     "passport": "^0.4.1",
     "passport-http": "^0.3.0",

--- a/backend/server/db/index.js
+++ b/backend/server/db/index.js
@@ -57,7 +57,7 @@ exports.getScenarioIntroduction = (scenario_id) => {
   }
 };
 
-// exports.getScenarioIntroductionByID = function (token, scenario_id) {
+// exports.getScenarioIntroductionByID = function (scenario_id) {
 //   const scenario = scenarios.find((ele) => ele.scenario_id === scenario_id);
 //   if (scenario) {
 //     return scenario.introduction;
@@ -66,7 +66,7 @@ exports.getScenarioIntroduction = (scenario_id) => {
 //   }
 // };
 
-// exports.setScenarioIntroductionByID = function (token, scenario_id, summary) {
+// exports.setScenarioIntroductionByID = function (scenario_id, summary) {
 //   const scenario = scenarios.find((ele) => ele.scenario_id === scenario_id);
 //   if (scenario) {
 //     scenario.introduction = summary;
@@ -85,7 +85,7 @@ exports.getScenarioSummary = function (scenario_id) {
   return "";
 };
 
-exports.getIntialReflectionQuestions = function (token) {
+exports.getIntialReflectionQuestions = function () {
   // returns an array of questions
   /**
    * /scenario/:scenario_id/initial-reflection
@@ -94,7 +94,7 @@ exports.getIntialReflectionQuestions = function (token) {
 };
 
 // have to work on this
-exports.getStudentName = function (token) {
+exports.getStudentName = function () {
   /**
    * /scenario/:scenario_id/initial-reflection/answers
    * /scenario/:scenario_id/initial-action/answers
@@ -104,7 +104,7 @@ exports.getStudentName = function (token) {
 };
 
 // have to work on this
-exports.getStudentUID = function (token) {
+exports.getStudentUID = function () {
   /**
    * /scenario/:scenario_id/initial-reflection/answers
    * /scenario/:scenario_id/initial-action/answers
@@ -113,7 +113,7 @@ exports.getStudentUID = function (token) {
   return 0;
 };
 
-exports.getStudentResponses = function (token) {
+exports.getStudentResponses = function () {
   // an array of json with keys 'question', 'answer'.
   /**
    * /scenario/:scenario_id/initial-reflection/answers
@@ -122,15 +122,15 @@ exports.getStudentResponses = function (token) {
   return [];
 };
 
-exports.getQuestion = function (token) {
+exports.getQuestion = function () {
   return "";
 };
 
-exports.getAnswer = function (token) {
+exports.getAnswer = function () {
   return "";
 };
 
-exports.getIntialActionQuestions = function (instructor_token) {
+exports.getIntialActionQuestions = function () {
   // an array of json with keys 'question', 'choices'.
   /**
    * /scenario/:scenario_id/initial-action
@@ -138,7 +138,7 @@ exports.getIntialActionQuestions = function (instructor_token) {
   return [];
 };
 
-exports.getChoices = function (token) {
+exports.getChoices = function () {
   // return : array of string.
   /**
    * /scenario/:scenario_id/initial-action
@@ -146,7 +146,7 @@ exports.getChoices = function (token) {
   return [];
 };
 
-exports.getscenarioExplanation = function (token) {
+exports.getscenarioExplanation = function () {
   /**
     /scenario/:scenario_id/additional-reflection
     /scenario/:scenario_id/final-decision
@@ -154,7 +154,7 @@ exports.getscenarioExplanation = function (token) {
   return "";
 };
 
-exports.getStudentExplanation = function (token) {
+exports.getStudentExplanation = function () {
   /**
    /scenario/:scenario_id/additional-reflection
    /scenario/:scenario_id/final-decision
@@ -162,14 +162,14 @@ exports.getStudentExplanation = function (token) {
   return "";
 };
 
-exports.getStakeHolderSummary = function (token) {
+exports.getStakeHolderSummary = function () {
   /**
    * /scenario/:scenario_id/stakeholders/description
    */
   return "";
 };
 
-exports.getStakeHolder_ids = function (token) {
+exports.getStakeHolder_ids = function () {
   // an list of ids
   /**
 
@@ -180,7 +180,7 @@ exports.getStakeHolder_ids = function (token) {
 
 // http://localhost:3000/api/v1/scenario/:scenario_id/stakeholders/:stakeholder_id
 
-exports.getStakeHolderName = function (token) {
+exports.getStakeHolderName = function () {
   /**
    * /scenario/:scenario_id/stakeholders/:stakeholder_id
    */
@@ -189,7 +189,7 @@ exports.getStakeHolderName = function (token) {
 
 // http://localhost:3000/api/v1/scenario/:scenario_id/stakeholders/:stakeholder_id
 
-exports.getStakeHolderDescription = function (token) {
+exports.getStakeHolderDescription = function () {
   /**
    * /scenario/:scenario_id/stakeholders/:stakeholder_id
    */
@@ -198,14 +198,14 @@ exports.getStakeHolderDescription = function (token) {
 
 // http://localhost:3000/api/v1/scenario/:scenario_id/stakeholders/:stakeholder_id
 
-exports.getStakeHolderConversation_text = function (token) {
+exports.getStakeHolderConversation_text = function () {
   /**
    * /scenario/:scenario_id/stakeholders/:stakeholder_id
    */
   return "";
 };
 
-exports.getScenariosConversants = function (token) {
+exports.getScenariosConversants = function () {
   // return : array of string
   /**
    * /scenario/:scenario_id/issue-coverage-matrix
@@ -213,7 +213,7 @@ exports.getScenariosConversants = function (token) {
   return [];
 };
 
-exports.getScenarioIssues = function (token) {
+exports.getScenarioIssues = function () {
   // return : array of string (issues)
   /**
    * /scenario/:scenario_id/issue-coverage-matrix
@@ -221,7 +221,7 @@ exports.getScenarioIssues = function (token) {
   return [];
 };
 
-exports.getScenarioValues = function (token) {
+exports.getScenarioValues = function () {
   // return : 2-d array, with each inner array corresponding to each issues and conversants
   /**
    * /scenario/:scenario_id/issue-coverage-matrix
@@ -231,7 +231,7 @@ exports.getScenarioValues = function (token) {
 
 // http://localhost:3000/api/v1/scenario/:scenario_id/students
 
-exports.getStudents_scenarioInfo = function (token) {
+exports.getStudents_scenarioInfo = function () {
   /**
    * /scenario/:scenario_id/students
    */
@@ -240,14 +240,14 @@ exports.getStudents_scenarioInfo = function (token) {
 
 // scenarios
 
-exports.getScenarioSummary = function (token) {
+exports.getScenarioSummary = function () {
   /**
    * /scenario/:scenario_id/scenarios/:scenario_id/summary
    */
   return "";
 };
 
-exports.getScenarioID = function (token) {
+exports.getScenarioID = function () {
   // return a list of scenario id's
   /**
    * /scenario/:scenario_id/scenarios

--- a/backend/server/middleware/auth.js
+++ b/backend/server/middleware/auth.js
@@ -1,18 +1,45 @@
+const jwt = require('jsonwebtoken');
 const { httpStatusCode } = require("../constant");
 const { createInvalidResponse } = require("../utils");
 
 exports.isAuthenticated = (req, res, next) => {
   if (process.env.NODE_ENV === "dev") return next();
-  if (req.isAuthenticated()) return next();
-  const msg = "Invalid authorization token.";
-  res.status(httpStatusCode.failed.UNAUTHORIZED);
-  res.json(createInvalidResponse(msg));
+
+  if (!req.headers.hasOwnProperty("Authorization") &&
+      !req.headers.hasOwnProperty("authorization")) {
+    const msg = "Missing authorization token.";
+    res.status(httpStatusCode.failed.UNAUTHORIZED);
+    res.json(createInvalidResponse(msg));
+    return;
+  }
+
+  token = req.headers.authorization.split(" ")[1];
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    next();
+  } catch(err) {
+    const msg = "Invalid authorization token.";
+    res.status(httpStatusCode.failed.UNAUTHORIZED);
+    res.json(createInvalidResponse(msg));
+  }
 };
 
 exports.isNotAuthenticated = (req, res, next) => {
   if (process.env.NODE_ENV === "dev") return next();
-  if (!req.isAuthenticated()) return next();
-  const msg = "The user already has valid token.";
-  res.status(httpStatusCode.failed.UNAUTHORIZED);
-  res.json(createInvalidResponse(msg));
+
+  if (!req.headers.hasOwnProperty("Authorization") &&
+      !req.headers.hasOwnProperty("authorization")) {
+    next();
+    return;
+  }
+
+  token = req.headers.authorization.split(" ")[1];
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    const msg = "The user already has valid token.";
+    res.status(httpStatusCode.failed.UNAUTHORIZED);
+    res.json(createInvalidResponse(msg));
+  } catch(err) {
+    next();
+  }
 };

--- a/backend/server/middleware/headers.js
+++ b/backend/server/middleware/headers.js
@@ -43,6 +43,7 @@ const isAuthHeaderValid = (req, res, next) => {
   if (!auth_header) {
     // No tokens => login required
     next();
+    return;
   }
 
   const [prefix, token] = auth_header.split(" ");

--- a/backend/server/route/auth.js
+++ b/backend/server/route/auth.js
@@ -1,35 +1,26 @@
+const jwt = require('jsonwebtoken');
 const express = require("express");
 const { auth, headers } = require("../middleware");
 const router = express.Router();
 
-router.get(
-  "/login",
+router.post(
+  "/login/callback",
   headers.areHeadersValid,
   auth.isNotAuthenticated,
   (req, res, next) => {
+    // TODO: Check SAML properties.
+    const token = jwt.sign({
+      role: "instructor",
+      identity: "Professor McProfessorface",
+    }, process.env.JWT_SECRET, { expiresIn: 60 * 60});
     res.status(202);
-    res.json({ token: "abcdefghijklmnopqrstuvwxyz" });
-    // passport.authenticate('local', (err, user, info) => {
-    //   if (err) {
-    //     return next(err);
-    //   }
-    //   if (!user) {
-    //     return res.json({ error: info.message }); // Don't want 401 here
-    //   }
-    //   req.logIn(user, function (err) {
-    //     if (err) {
-    //       return next(err);
-    //     }
-    //     let { first_name, last_name, email } = user;
-    //     res.json({ first_name, last_name, email });
-    //     return next();
-    //   });
-    // })(req, res, next);
+    res.cookie('authorization', "Bearer " + token);
+    res.json({ token: token });
   }
 );
 
 router.get("/logout", function (req, res) {
-  req.logout();
+  res.clearCookie("authorization");
   res.redirect("/");
 });
 

--- a/backend/server/route/dashboard.js
+++ b/backend/server/route/dashboard.js
@@ -7,7 +7,6 @@ router.get(
   headers.areHeadersValid,
   auth.isAuthenticated,
   async (req, res) => {
-    const { token } = req;
     res.status(202);
     res.json({
       drafts: await db.getScenariosBy({status: "DRAFT"}),

--- a/backend/server/route/simulation.js
+++ b/backend/server/route/simulation.js
@@ -162,7 +162,6 @@ router.put(
   (req, res) => {
     try {
       const introduction = db.getSimulationIntroductionByID(
-        req.token,
         req.params.simulation_id
       );
       res.status(httpStatusCode.success.OK);


### PR DESCRIPTION
This adds a big pain in the rear that can be disabled by setting `NODE_ENV` to `dev`.

Also, PLEASE review this thoroughly because I've scrapped a lot of things we originally had.

When we can eventually register as a Shibboleth SP, the login callback will set a cookie with a JWT containing information about i.e. whether or not the user is an instructor. For now, `/auth/login/callback` is a dummy endpoint that unconditionally sets an instructor cookie. You still need to pass that cookie as an HTTP header.

Criticisms of this approach are appreciated.